### PR TITLE
fix: To ensure a successful build, declear the variable

### DIFF
--- a/src/mcl_node.cpp
+++ b/src/mcl_node.cpp
@@ -138,7 +138,9 @@ void MclNode::loop(void)
 	publishPose(x, y, t, x_var, y_var, t_var, xy_cov, yt_cov, tx_cov);
 	publishParticles();
 
-	alpha_pub_.publish((float)pf_->alpha_);
+	std_msgs::Float32 alpha_msg;
+	alpha_msg.data = static_cast<float>pf_->alpha_;
+	alpha_pub_.publish(alpha_msg);
 }
 
 void MclNode::publishPose(double x, double y, double t,


### PR DESCRIPTION
# Build failed
## Environment
docker 
+ ros:kinetic
+ ros:melodic
+ ros:noetic

## Description
I got an error when I tried to build it.

```
$ cd ~/catkin_ws
$ catkin_make_isolated
```

result
```
Scanning dependencies of target emcl_node                                                                                                                                                                   
[ 91%] Building CXX object CMakeFiles/emcl_node.dir/src/mcl_node.cpp.o                                                                                                                                      
In file included from /opt/ros/melodic/include/ros/serialization.h:37:0,                                                                                                                                    
                 from /opt/ros/melodic/include/ros/publisher.h:34,                                                                                                                                          
                 from /opt/ros/melodic/include/ros/node_handle.h:32,                                                                                                                                        
                 from /opt/ros/melodic/include/ros/ros.h:45,                                                                                                                                                
                 from /root/catkin_ws/src/emcl/include/mcl/mcl_node.h:13,                                                                                                                                   
                 from /root/catkin_ws/src/emcl/src/mcl_node.cpp:9:                                                                                                                                          
/opt/ros/melodic/include/ros/message_traits.h: In instantiation of ‘static const char* ros::message_traits::MD5Sum<M>::value(const M&) [with M = float]’:                                                   
/opt/ros/melodic/include/ros/message_traits.h:255:102:   required from ‘const char* ros::message_traits::md5sum(const M&) [with M = float]’
/opt/ros/melodic/include/ros/publisher.h:113:7:   required from ‘void ros::Publisher::publish(const M&) const [with M = float]’
/root/catkin_ws/src/emcl/src/mcl_node.cpp:141:39:   required from here
/opt/ros/melodic/include/ros/message_traits.h:126:14: error: request for member ‘__getMD5Sum’ in ‘m’, which is of non-class type ‘const float’
     return m.__getMD5Sum().c_str();
            ~~^~~~~~~~~~~
/opt/ros/melodic/include/ros/message_traits.h: In instantiation of ‘static const char* ros::message_traits::DataType<M>::value(const M&) [with M = float]’:
/opt/ros/melodic/include/ros/message_traits.h:264:104:   required from ‘const char* ros::message_traits::datatype(const M&) [with M = float]’
/opt/ros/melodic/include/ros/publisher.h:113:7:   required from ‘void ros::Publisher::publish(const M&) const [with M = float]’
/root/catkin_ws/src/emcl/src/mcl_node.cpp:141:39:   required from here
/opt/ros/melodic/include/ros/message_traits.h:143:14: error: request for member ‘__getDataType’ in ‘m’, which is of non-class type ‘const float’
     return m.__getDataType().c_str();
            ~~^~~~~~~~~~~~~
CMakeFiles/emcl_node.dir/build.make:62: recipe for target 'CMakeFiles/emcl_node.dir/src/mcl_node.cpp.o' failed
make[2]: *** [CMakeFiles/emcl_node.dir/src/mcl_node.cpp.o] Error 1
CMakeFiles/Makefile2:106: recipe for target 'CMakeFiles/emcl_node.dir/all' failed
make[1]: *** [CMakeFiles/emcl_node.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2
<== Failed to process package 'emcl':
  Command '['make', '-j8', '-l8']' returned non-zero exit status 2

Reproduce this error by running:
==> cd /root/catkin_ws/build_isolated/emcl && make -j8 -l8

Command failed, exiting.
```

To fix this error, I declear the varible.
We should send an std_msgs/Float32 not an float.