### PR TITLE
fix: fix bug of not update scan.range_min_ and range_max_ in ignition…

### DIFF
--- a/src/ParticleFilter.cpp
+++ b/src/ParticleFilter.cpp
@@ -213,6 +213,8 @@ void ParticleFilter::setScan(const sensor_msgs::LaserScan::ConstPtr &msg)
 	scan_.angle_min_ = msg->angle_min;
 	scan_.angle_max_ = msg->angle_max;
 	scan_.angle_increment_ = msg->angle_increment;
+	scan_.range_min_= msg->range_min;
+	scan_.range_max_= msg->range_max;
 }
 
 double ParticleFilter::normalize(void)


### PR DESCRIPTION
I found a bug of not working sensor update step like [this video](https://youtu.be/lHjtDKWqapo)
This bug is caused by the value, scan.range_min_ and range_max_, not updated properly.
This PR is to fix this bug.

## Environment
+ ROS melodic
+ Ignition Gazebo CItadel (version 3.3.0)