### PR TITLE
Fix incorrect behavior when running 2D Pose Estimate

### DIFF
--- a/src/mcl_node.cpp
+++ b/src/mcl_node.cpp
@@ -118,7 +118,7 @@ void MclNode::initialPoseReceived(const geometry_msgs::PoseWithCovarianceStamped
 	init_request_ = true;
 	init_x_ = msg->pose.pose.position.x;
 	init_y_ = msg->pose.pose.position.y;
-	init_t_ = msg->pose.pose.orientation.z;
+	init_t_ = tf2::getYaw(msg->pose.pose.orientation);
 }
 
 void MclNode::loop(void)


### PR DESCRIPTION
I found that it behaves incorrectly when running 2D Pose Estimate. 
That is, it does not become the robot posture executed by 2D Pose Estimate. 
[This video is a comparison video before and after the correction so that the robot posture is reflected well.](https://youtu.be/3OQpQCH7esw)
In this video, α, which is the threshold for expansion reset, is set to 0 to make it easier to experiment.

# Environment
* ROS melodic